### PR TITLE
Add import inclusion feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,6 +459,7 @@ Instruction
 - `-i, --ignore <patterns>`: Additional ignore patterns (comma-separated)
 - `--no-gitignore`: Disable .gitignore file usage
 - `--no-default-patterns`: Disable default patterns
+- `--include-imports-depth <number>`: Include imported files up to the specified depth (JavaScript/TypeScript, Python, and Rust)
 
 #### Remote Repository Options
 - `--remote <url>`: Process a remote Git repository

--- a/src/cli/actions/defaultAction.ts
+++ b/src/cli/actions/defaultAction.ts
@@ -114,6 +114,9 @@ export const buildCliConfig = (options: CliOptions): RepomixConfigCli => {
       useDefaultPatterns: options.defaultPatterns,
     };
   }
+  if (options.includeImportsDepth !== undefined) {
+    cliConfig.includeImportsDepth = options.includeImportsDepth;
+  }
   if (options.topFilesLen !== undefined) {
     cliConfig.output = {
       ...cliConfig.output,

--- a/src/cli/cliRun.ts
+++ b/src/cli/cliRun.ts
@@ -77,6 +77,11 @@ export const run = async () => {
       .option('-i, --ignore <patterns>', 'additional ignore patterns (comma-separated)')
       .option('--no-gitignore', 'disable .gitignore file usage')
       .option('--no-default-patterns', 'disable default patterns')
+      .option(
+        '--include-imports-depth <number>',
+        'include imported files up to specified depth (JavaScript/TypeScript, Python, Rust)',
+        Number.parseInt,
+      )
       // Remote Repository Options
       .option('--remote <url>', 'process a remote Git repository')
       .option(

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -29,6 +29,7 @@ export interface CliOptions extends OptionValues {
   ignore?: string;
   gitignore?: boolean;
   defaultPatterns?: boolean;
+  includeImportsDepth?: number;
 
   // Remote Repository Options
   remote?: string;

--- a/src/config/configSchema.ts
+++ b/src/config/configSchema.ts
@@ -47,6 +47,7 @@ export const repomixConfigBaseSchema = z.object({
     })
     .optional(),
   include: z.array(z.string()).optional(),
+  includeImportsDepth: z.number().int().min(0).optional(),
   ignore: z
     .object({
       useGitignore: z.boolean().optional(),
@@ -104,6 +105,7 @@ export const repomixConfigDefaultSchema = z.object({
     })
     .default({}),
   include: z.array(z.string()).default([]),
+  includeImportsDepth: z.number().int().min(0).default(0),
   ignore: z
     .object({
       useGitignore: z.boolean().default(true),

--- a/src/core/file/fileImportCollect.ts
+++ b/src/core/file/fileImportCollect.ts
@@ -1,0 +1,288 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { logger } from '../../shared/logger.js';
+
+/**
+ * Handler for extracting and resolving imports for a specific language.
+ */
+interface ImportHandler {
+  extensions: string[];
+  extract: (content: string) => string[];
+  resolve: (
+    importPath: string,
+    fromFile: string,
+    rootDir: string,
+  ) => Promise<string | null>;
+}
+
+// -------- JavaScript/TypeScript --------
+const JS_IMPORT_RE = /import(?:[^'";]*?from\s*)?["']([^"']+)["']/g;
+const REQUIRE_RE = /require\(["']([^"']+)["']\)/g;
+const EXPORT_RE = /export\s+[^'";]*?from\s*["']([^"']+)["']/g;
+
+const extractJsImports = (content: string): string[] => {
+  const paths = new Set<string>();
+  for (const regex of [JS_IMPORT_RE, REQUIRE_RE, EXPORT_RE]) {
+    regex.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = regex.exec(content)) !== null) {
+      paths.add(match[1]);
+    }
+  }
+  return Array.from(paths);
+};
+
+const resolveJSImport = async (
+  importPath: string,
+  fromFile: string,
+  rootDir: string,
+): Promise<string | null> => {
+  if (!importPath.startsWith('.')) {
+    return null;
+  }
+  const baseDir = path.dirname(path.resolve(rootDir, fromFile));
+  const candidates = [
+    importPath,
+    `${importPath}.ts`,
+    `${importPath}.js`,
+    `${importPath}.tsx`,
+    `${importPath}.jsx`,
+    path.join(importPath, 'index.ts'),
+    path.join(importPath, 'index.js'),
+  ];
+  for (const candidate of candidates) {
+    const resolved = path.relative(rootDir, path.resolve(baseDir, candidate));
+    try {
+      const stat = await fs.stat(path.resolve(rootDir, resolved));
+      if (stat.isFile()) {
+        return resolved;
+      }
+    } catch {
+      // ignore
+    }
+  }
+  return null;
+};
+
+const jsHandler: ImportHandler = {
+  extensions: ['.js', '.jsx', '.ts', '.tsx'],
+  extract: extractJsImports,
+  resolve: resolveJSImport,
+};
+
+// -------- C/C++ (for #include) --------
+const INCLUDE_RE = /#include\s+[<"]([^">]+)[">]/g;
+
+const extractCImports = (content: string): string[] => {
+  const paths: string[] = [];
+  INCLUDE_RE.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = INCLUDE_RE.exec(content)) !== null) {
+    paths.push(match[1]);
+  }
+  return paths;
+};
+
+const resolveCImport = async (
+  importPath: string,
+  fromFile: string,
+  rootDir: string,
+): Promise<string | null> => {
+  if (!importPath.startsWith('.')) {
+    return null;
+  }
+  const baseDir = path.dirname(path.resolve(rootDir, fromFile));
+  const resolved = path.relative(rootDir, path.resolve(baseDir, importPath));
+  try {
+    const stat = await fs.stat(path.resolve(rootDir, resolved));
+    if (stat.isFile()) {
+      return resolved;
+    }
+  } catch {
+    // ignore
+  }
+  return null;
+};
+
+const cHandler: ImportHandler = {
+  extensions: ['.c', '.cpp', '.h', '.hpp'],
+  extract: extractCImports,
+  resolve: resolveCImport,
+};
+
+// -------- Python --------
+const PY_FROM_RE = /^\s*from\s+([.\w]+)\s+import/m;
+const PY_IMPORT_RE = /^\s*import\s+([.\w, ]+)/m;
+
+const extractPythonImports = (content: string): string[] => {
+  const imports = new Set<string>();
+  const lines = content.split('\n');
+  for (const line of lines) {
+    let match = line.match(PY_FROM_RE);
+    if (match) {
+      imports.add(match[1]);
+      continue;
+    }
+    match = line.match(PY_IMPORT_RE);
+    if (match) {
+      for (const part of match[1].split(',')) {
+        const trimmed = part.trim();
+        if (trimmed) imports.add(trimmed);
+      }
+    }
+  }
+  return Array.from(imports);
+};
+
+const resolvePythonImport = async (
+  importPath: string,
+  fromFile: string,
+  rootDir: string,
+): Promise<string | null> => {
+  const baseDir = path.dirname(path.resolve(rootDir, fromFile));
+
+  const leadingDots = importPath.match(/^\.+/);
+  let targetDir = baseDir;
+  let relative = importPath;
+
+  if (leadingDots) {
+    // Relative import like ..module.utils
+    const level = leadingDots[0].length;
+    relative = importPath.slice(level);
+    for (let i = 1; i < level; i += 1) {
+      targetDir = path.dirname(targetDir);
+    }
+  } else {
+    // Absolute import from project root
+    targetDir = rootDir;
+  }
+
+  if (!relative) {
+    return null;
+  }
+
+  const modulePath = relative.replace(/\./g, '/');
+  const candidates = [
+    `${modulePath}.py`,
+    path.join(modulePath, '__init__.py'),
+  ];
+
+  for (const candidate of candidates) {
+    const resolved = path.relative(rootDir, path.resolve(targetDir, candidate));
+    try {
+      const stat = await fs.stat(path.resolve(rootDir, resolved));
+      if (stat.isFile()) {
+        return resolved;
+      }
+    } catch {
+      // ignore
+    }
+  }
+
+  return null;
+};
+
+const pythonHandler: ImportHandler = {
+  extensions: ['.py'],
+  extract: extractPythonImports,
+  resolve: resolvePythonImport,
+};
+
+// -------- Rust --------
+const RUST_MOD_RE = /(?:^|\s)(?:pub\s+)?mod\s+([A-Za-z0-9_]+)\s*;/gm;
+const RUST_INCLUDE_RE = /include!\s*\(\s*"([^"]+)"\s*\)/gm;
+
+const extractRustImports = (content: string): string[] => {
+  const imports = new Set<string>();
+  for (const regex of [RUST_MOD_RE, RUST_INCLUDE_RE]) {
+    regex.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = regex.exec(content)) !== null) {
+      imports.add(match[1]);
+    }
+  }
+  return Array.from(imports);
+};
+
+const resolveRustImport = async (
+  importPath: string,
+  fromFile: string,
+  rootDir: string,
+): Promise<string | null> => {
+  const baseDir = path.dirname(path.resolve(rootDir, fromFile));
+
+  const candidates = importPath.endsWith('.rs')
+    ? [importPath]
+    : [`${importPath}.rs`, path.join(importPath, 'mod.rs')];
+
+  for (const candidate of candidates) {
+    const resolved = path.relative(rootDir, path.resolve(baseDir, candidate));
+    try {
+      const stat = await fs.stat(path.resolve(rootDir, resolved));
+      if (stat.isFile()) {
+        return resolved;
+      }
+    } catch {
+      // ignore
+    }
+  }
+
+  return null;
+};
+
+const rustHandler: ImportHandler = {
+  extensions: ['.rs'],
+  extract: extractRustImports,
+  resolve: resolveRustImport,
+};
+
+const handlers: ImportHandler[] = [
+  jsHandler,
+  cHandler,
+  pythonHandler,
+  rustHandler,
+];
+
+const getHandlersForExt = (ext: string): ImportHandler[] =>
+  handlers.filter((h) => h.extensions.includes(ext));
+
+export const collectImportedFiles = async (
+  startFiles: string[],
+  rootDir: string,
+  maxDepth: number,
+): Promise<string[]> => {
+  const queue: Array<{ file: string; depth: number }> = startFiles.map((f) => ({
+    file: f,
+    depth: 0,
+  }));
+  const visited = new Set<string>();
+  const results = new Set<string>();
+
+  while (queue.length > 0) {
+    const { file, depth } = queue.shift()!;
+    if (depth >= maxDepth) continue;
+
+    let content: string;
+    try {
+      content = await fs.readFile(path.resolve(rootDir, file), 'utf8');
+    } catch (err) {
+      logger.debug(`collectImportedFiles: failed to read ${file}: ${err}`);
+      continue;
+    }
+
+    const ext = path.extname(file);
+    for (const handler of getHandlersForExt(ext)) {
+      const importPaths = handler.extract(content);
+      for (const imp of importPaths) {
+        const resolved = await handler.resolve(imp, file, rootDir);
+        if (resolved && !visited.has(resolved)) {
+          visited.add(resolved);
+          results.add(resolved);
+          queue.push({ file: resolved, depth: depth + 1 });
+        }
+      }
+    }
+  }
+
+  return Array.from(results);
+};

--- a/src/core/file/fileSearch.ts
+++ b/src/core/file/fileSearch.ts
@@ -8,6 +8,7 @@ import { RepomixError } from '../../shared/errorHandle.js';
 import { logger } from '../../shared/logger.js';
 import { sortPaths } from './filePathSort.js';
 import { PermissionError, checkDirectoryPermissions } from './permissionCheck.js';
+import { collectImportedFiles } from './fileImportCollect.js';
 
 export interface FileSearchResult {
   filePaths: string[];
@@ -170,6 +171,15 @@ export const searchFiles = async (rootDir: string, config: RepomixConfigMerged):
     }
 
     logger.trace(`Filtered ${filePaths.length} files`);
+
+    if (config.includeImportsDepth && config.includeImportsDepth > 0) {
+      const imported = await collectImportedFiles(filePaths, rootDir, config.includeImportsDepth);
+      for (const f of imported) {
+        if (!filePaths.includes(f)) {
+          filePaths.push(f);
+        }
+      }
+    }
 
     return {
       filePaths: sortPaths(filePaths),

--- a/tests/core/file/fileImportCollect.test.ts
+++ b/tests/core/file/fileImportCollect.test.ts
@@ -1,0 +1,47 @@
+import * as fs from 'node:fs/promises';
+import { describe, expect, test, vi } from 'vitest';
+import { collectImportedFiles } from '../../../src/core/file/fileImportCollect.js';
+
+vi.mock('node:fs/promises');
+
+describe('collectImportedFiles', () => {
+  test('collects imports recursively up to depth', async () => {
+    const files: Record<string, string> = {
+      '/root/main.js': "import './a.js'; const b = require('./b');",
+      '/root/a.js': "export * from './c.js';",
+      '/root/b.js': '',
+      '/root/c.js': '',
+    };
+    vi.mocked(fs.readFile).mockImplementation(async (p: any) => files[p as string] || '');
+    vi.mocked(fs.stat).mockResolvedValue({ isFile: () => true } as any);
+
+    const result = await collectImportedFiles(['main.js'], '/root', 2);
+    expect(result.sort()).toEqual(['a.js', 'b.js', 'c.js'].sort());
+  });
+
+  test('collects python imports', async () => {
+    const files: Record<string, string> = {
+      '/root/main.py': 'from .pkg import mod\nimport util',
+      '/root/pkg/mod.py': '',
+      '/root/util.py': '',
+    };
+    vi.mocked(fs.readFile).mockImplementation(async (p: any) => files[p as string] || '');
+    vi.mocked(fs.stat).mockResolvedValue({ isFile: () => true } as any);
+
+    const result = await collectImportedFiles(['main.py'], '/root', 1);
+    expect(result.sort()).toEqual(['pkg/mod.py', 'util.py'].sort());
+  });
+
+  test('collects rust mod and include', async () => {
+    const files: Record<string, string> = {
+      '/root/main.rs': 'mod foo;\ninclude!("bar.rs");',
+      '/root/foo.rs': '',
+      '/root/bar.rs': '',
+    };
+    vi.mocked(fs.readFile).mockImplementation(async (p: any) => files[p as string] || '');
+    vi.mocked(fs.stat).mockResolvedValue({ isFile: () => true } as any);
+
+    const result = await collectImportedFiles(['main.rs'], '/root', 1);
+    expect(result.sort()).toEqual(['bar.rs', 'foo.rs'].sort());
+  });
+});

--- a/tests/testing/testUtils.ts
+++ b/tests/testing/testUtils.ts
@@ -33,6 +33,7 @@ export const createMockConfig = (config: DeepPartial<RepomixConfigMerged> = {}):
       customPatterns: [...(defaultConfig.ignore.customPatterns || []), ...(config.ignore?.customPatterns || [])],
     },
     include: [...(defaultConfig.include || []), ...(config.include || [])],
+    includeImportsDepth: config.includeImportsDepth ?? defaultConfig.includeImportsDepth,
     security: {
       ...defaultConfig.security,
       ...config.security,

--- a/website/client/src/en/guide/command-line-options.md
+++ b/website/client/src/en/guide/command-line-options.md
@@ -27,6 +27,7 @@
 - `-i, --ignore <patterns>`: Ignore patterns (comma-separated)
 - `--no-gitignore`: Disable .gitignore file usage
 - `--no-default-patterns`: Disable default patterns
+- `--include-imports-depth <number>`: Include imported files up to the specified depth (JavaScript/TypeScript, Python, and Rust)
 
 ## Remote Repository Options
 - `--remote <url>`: Process remote repository


### PR DESCRIPTION
## Notes
- Lint and tests failed due to missing `biome` and `vitest` in the execution environment.

## Summary
- allow CLI `--include-imports-depth` option
- store depth config as `includeImportsDepth`
- collect imported files up to the configured depth
- document new option in README and website docs
- add unit test for collecting imports
