### PR TITLE
Add recursive import inclusion

### DIFF
--- a/src/config/configSchema.ts
+++ b/src/config/configSchema.ts
@@ -18,6 +18,12 @@ export const repomixConfigBaseSchema = z.object({
   input: z
     .object({
       maxFileSize: z.number().optional(),
+      imports: z
+        .object({
+          enabled: z.boolean().optional(),
+          maxDepth: z.number().int().min(1).optional(),
+        })
+        .optional(),
     })
     .optional(),
   output: z
@@ -75,6 +81,12 @@ export const repomixConfigDefaultSchema = z.object({
         .int()
         .min(1)
         .default(50 * 1024 * 1024), // Default: 50MB
+      imports: z
+        .object({
+          enabled: z.boolean().default(false),
+          maxDepth: z.number().int().min(1).default(3),
+        })
+        .default({}),
     })
     .default({}),
   output: z

--- a/src/core/file/importResolver.ts
+++ b/src/core/file/importResolver.ts
@@ -1,0 +1,95 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { minimatch } from 'minimatch';
+import type { RepomixConfigMerged } from '../../config/configSchema.js';
+import { logger } from '../../shared/logger.js';
+import { readRawFile } from './fileRead.js';
+import { getIgnorePatterns } from './fileSearch.js';
+
+const possibleExtensions = ['', '.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs', '.json'];
+
+const extractImports = (content: string): string[] => {
+  const result: string[] = [];
+  const importRegex = /import\s+(?:[^'";]+\s+from\s+)?['"]([^'";]+)['"]/g;
+  const requireRegex = /require\(\s*['"]([^'";]+)['"]\s*\)/g;
+  let match: RegExpExecArray | null;
+  while ((match = importRegex.exec(content))) {
+    result.push(match[1]);
+  }
+  while ((match = requireRegex.exec(content))) {
+    result.push(match[1]);
+  }
+  return result.filter((p) => p.startsWith('.'));
+};
+
+const resolveImportPath = async (
+  spec: string,
+  fromDir: string,
+  rootDir: string,
+): Promise<string | null> => {
+  const basePath = path.normalize(path.join(fromDir, spec));
+  for (const ext of possibleExtensions) {
+    const filePath = path.join(rootDir, basePath + ext);
+    try {
+      const stats = await fs.stat(filePath);
+      if (stats.isFile()) {
+        return path.relative(rootDir, filePath);
+      }
+    } catch {
+      // ignore
+    }
+  }
+  for (const ext of possibleExtensions) {
+    const indexPath = path.join(rootDir, basePath, 'index' + ext);
+    try {
+      const stats = await fs.stat(indexPath);
+      if (stats.isFile()) {
+        return path.relative(rootDir, indexPath);
+      }
+    } catch {
+      // ignore
+    }
+  }
+  return null;
+};
+
+export const collectImportedFilePaths = async (
+  filePaths: string[],
+  rootDir: string,
+  config: RepomixConfigMerged,
+): Promise<string[]> => {
+  const importsConfig = config.input.imports;
+  if (!importsConfig?.enabled) {
+    return [];
+  }
+  const maxDepth = importsConfig.maxDepth ?? 3;
+  const ignorePatterns = await getIgnorePatterns(rootDir, config);
+
+  const visited = new Set<string>(filePaths);
+  const additional: string[] = [];
+  const queue = filePaths.map((p) => ({ path: p, depth: 0 }));
+
+  while (queue.length > 0) {
+    const { path: current, depth } = queue.shift()!;
+    if (depth >= maxDepth) continue;
+    const fullPath = path.join(rootDir, current);
+    const content = await readRawFile(fullPath, config.input.maxFileSize);
+    if (!content) continue;
+    const imports = extractImports(content);
+    for (const spec of imports) {
+      const resolved = await resolveImportPath(spec, path.dirname(current), rootDir);
+      if (!resolved) continue;
+      if (ignorePatterns.some((pattern) => minimatch(resolved, pattern))) {
+        continue;
+      }
+      if (!visited.has(resolved)) {
+        visited.add(resolved);
+        additional.push(resolved);
+        queue.push({ path: resolved, depth: depth + 1 });
+      }
+    }
+  }
+
+  logger.trace(`Collected ${additional.length} imported files`);
+  return additional;
+};

--- a/src/core/packager.ts
+++ b/src/core/packager.ts
@@ -5,6 +5,7 @@ import { sortPaths } from './file/filePathSort.js';
 import { processFiles } from './file/fileProcess.js';
 import { searchFiles } from './file/fileSearch.js';
 import type { RawFile } from './file/fileTypes.js';
+import { collectImportedFilePaths } from './file/importResolver.js';
 import { GitDiffResult, getGitDiffs } from './git/gitDiff.js';
 import { calculateMetrics } from './metrics/calculateMetrics.js';
 import { generateOutput } from './output/outputGenerate.js';
@@ -26,6 +27,7 @@ export interface PackResult {
 
 const defaultDeps = {
   searchFiles,
+  collectImportedFilePaths,
   collectFiles,
   processFiles,
   generateOutput,
@@ -50,10 +52,15 @@ export const pack = async (
 
   progressCallback('Searching for files...');
   const filePathsByDir = await Promise.all(
-    rootDirs.map(async (rootDir) => ({
-      rootDir,
-      filePaths: (await deps.searchFiles(rootDir, config)).filePaths,
-    })),
+    rootDirs.map(async (rootDir) => {
+      const searchResult = await deps.searchFiles(rootDir, config);
+      const imported = await deps.collectImportedFilePaths(searchResult.filePaths, rootDir, config);
+      const combined = Array.from(new Set([...searchResult.filePaths, ...imported]));
+      return {
+        rootDir,
+        filePaths: combined,
+      };
+    }),
   );
 
   // Sort file paths

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ export { collectFiles } from './core/file/fileCollect.js';
 export { sortPaths } from './core/file/filePathSort.js';
 export { processFiles } from './core/file/fileProcess.js';
 export { searchFiles } from './core/file/fileSearch.js';
+export { collectImportedFilePaths } from './core/file/importResolver.js';
 export type { FileSearchResult } from './core/file/fileSearch.js';
 export { generateFileTree } from './core/file/fileTreeGenerate.js';
 

--- a/tests/config/configSchema.test.ts
+++ b/tests/config/configSchema.test.ts
@@ -62,6 +62,7 @@ describe('configSchema', () => {
       const validConfig = {
         input: {
           maxFileSize: 50 * 1024 * 1024,
+          imports: { enabled: false, maxDepth: 3 },
         },
         output: {
           filePath: 'output.txt',
@@ -156,6 +157,7 @@ describe('configSchema', () => {
         cwd: '/path/to/project',
         input: {
           maxFileSize: 50 * 1024 * 1024,
+          imports: { enabled: false, maxDepth: 3 },
         },
         output: {
           filePath: 'merged-output.txt',

--- a/tests/core/file/importResolver.test.ts
+++ b/tests/core/file/importResolver.test.ts
@@ -1,0 +1,133 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import { collectImportedFilePaths } from '../../../src/core/file/importResolver.js';
+import { createMockConfig } from '../../testing/testUtils.js';
+
+let tempDir: string;
+
+beforeEach(async () => {
+  tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'repomix-import-'));
+});
+
+afterEach(async () => {
+  await fs.rm(tempDir, { recursive: true, force: true });
+});
+
+describe('collectImportedFilePaths', () => {
+  test('collects imported files recursively', async () => {
+    await fs.writeFile(path.join(tempDir, 'index.js'), "import { greet } from './utils.js';");
+    await fs.writeFile(path.join(tempDir, 'utils.js'), "import { helper } from './helper.js'; export function greet() {};");
+    await fs.writeFile(path.join(tempDir, 'helper.js'), 'export const helper = () => {}');
+
+    const config = createMockConfig({
+      include: ['index.js'],
+      input: { imports: { enabled: true, maxDepth: 2 } },
+    });
+
+    const result = await collectImportedFilePaths(['index.js'], tempDir, config);
+    expect(result.sort()).toEqual(['helper.js', 'utils.js'].sort());
+  });
+
+  test('respects maxDepth', async () => {
+    await fs.writeFile(path.join(tempDir, 'index.js'), "import './a.js';");
+    await fs.writeFile(path.join(tempDir, 'a.js'), "import './b.js';");
+    await fs.writeFile(path.join(tempDir, 'b.js'), 'console.log(1);');
+
+    const config = createMockConfig({
+      include: ['index.js'],
+      input: { imports: { enabled: true, maxDepth: 1 } },
+    });
+
+    const result = await collectImportedFilePaths(['index.js'], tempDir, config);
+    expect(result).toEqual(['a.js']);
+  });
+
+  test('handles circular imports', async () => {
+    await fs.writeFile(path.join(tempDir, 'index.js'), "import './a.js';");
+    await fs.writeFile(path.join(tempDir, 'a.js'), "import './index.js';");
+
+    const config = createMockConfig({
+      include: ['index.js'],
+      input: { imports: { enabled: true, maxDepth: 5 } },
+    });
+
+    const result = await collectImportedFilePaths(['index.js'], tempDir, config);
+    expect(result).toEqual(['a.js']);
+  });
+
+  test('skips ignored imports', async () => {
+    await fs.writeFile(path.join(tempDir, 'index.js'), "import './ignored.js';");
+    await fs.writeFile(path.join(tempDir, 'ignored.js'), 'console.log(1);');
+
+    const config = createMockConfig({
+      include: ['index.js'],
+      input: { imports: { enabled: true } },
+      ignore: { customPatterns: ['ignored.js'] },
+    });
+
+    const result = await collectImportedFilePaths(['index.js'], tempDir, config);
+    expect(result).toEqual([]);
+  });
+
+  test('ignores missing imported files', async () => {
+    await fs.writeFile(path.join(tempDir, 'index.js'), "import './missing.js';");
+
+    const config = createMockConfig({
+      include: ['index.js'],
+      input: { imports: { enabled: true } },
+    });
+
+    const result = await collectImportedFilePaths(['index.js'], tempDir, config);
+    expect(result).toEqual([]);
+  });
+
+  test('resolves extensionless imports', async () => {
+    await fs.writeFile(path.join(tempDir, 'index.js'), "import './utils';");
+    await fs.writeFile(path.join(tempDir, 'utils.ts'), 'export const x = 1;');
+
+    const config = createMockConfig({
+      include: ['index.js'],
+      input: { imports: { enabled: true } },
+    });
+
+    const result = await collectImportedFilePaths(['index.js'], tempDir, config);
+    expect(result).toEqual(['utils.ts']);
+  });
+
+  test('supports require syntax', async () => {
+    await fs.writeFile(
+      path.join(tempDir, 'index.js'),
+      "const u = require('./util.js');",
+    );
+    await fs.writeFile(path.join(tempDir, 'util.js'), "import './helper.js';");
+    await fs.writeFile(path.join(tempDir, 'helper.js'), 'console.log(1);');
+
+    const config = createMockConfig({
+      include: ['index.js'],
+      input: { imports: { enabled: true } },
+    });
+
+    const result = await collectImportedFilePaths(['index.js'], tempDir, config);
+    expect(result.sort()).toEqual(['helper.js', 'util.js'].sort());
+  });
+
+  test('deduplicates imports from multiple entry files', async () => {
+    await fs.writeFile(path.join(tempDir, 'index.js'), "import './a.js';");
+    await fs.writeFile(path.join(tempDir, 'other.js'), "import './a.js';");
+    await fs.writeFile(path.join(tempDir, 'a.js'), 'console.log(1);');
+
+    const config = createMockConfig({
+      include: ['index.js', 'other.js'],
+      input: { imports: { enabled: true } },
+    });
+
+    const result = await collectImportedFilePaths(
+      ['index.js', 'other.js'],
+      tempDir,
+      config,
+    );
+    expect(result).toEqual(['a.js']);
+  });
+});

--- a/tests/testing/testUtils.ts
+++ b/tests/testing/testUtils.ts
@@ -18,6 +18,10 @@ export const createMockConfig = (config: DeepPartial<RepomixConfigMerged> = {}):
     input: {
       ...defaultConfig.input,
       ...config.input,
+      imports: {
+        ...defaultConfig.input.imports,
+        ...config.input?.imports,
+      },
     },
     output: {
       ...defaultConfig.output,


### PR DESCRIPTION
## Summary
- include imported files recursively with configurable depth
- expose API for collecting imported files
- update packer to gather imported dependencies
- add configuration schema and update tests
- expand coverage for circular and mixed import scenarios

## Testing
- `npm test`
