### PR TITLE
Add CLI option for import depth

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,6 +475,9 @@ Instruction
 #### Token Count Options
 - `--token-count-encoding <encoding>`: Specify token count encoding used by OpenAI's [tiktoken](https://github.com/openai/tiktoken) tokenizer (e.g., `o200k_base` for GPT-4o, `cl100k_base` for GPT-4/3.5). See [tiktoken model.py](https://github.com/openai/tiktoken/blob/main/tiktoken/model.py#L24) for encoding details.
 
+#### Import Options
+- `--imports-max-depth <number>`: Maximum depth for resolving imported files
+
 #### MCP
 - `--mcp`: Run as a [MCP (Model Context Protocol)](https://modelcontextprotocol.io) server
 
@@ -758,6 +761,8 @@ Here's an explanation of the configuration options:
 | Option                           | Description                                                                                                                  | Default                |
 |----------------------------------|------------------------------------------------------------------------------------------------------------------------------|------------------------|
 | `input.maxFileSize`              | Maximum file size in bytes to process. Files larger than this will be skipped                                                | `50000000`            |
+| `input.imports.enabled`          | Include imported files recursively | `false`                |
+| `input.imports.maxDepth`         | Maximum depth for resolving imports | `3`                    |
 | `output.filePath`                | The name of the output file                                                                                                  | `"repomix-output.xml"` |
 | `output.style`                   | The style of the output (`xml`, `markdown`, `plain`)                                                                         | `"xml"`                |
 | `output.parsableStyle`           | Whether to escape the output based on the chosen style schema. Note that this can increase token count.                      | `false`                |
@@ -794,7 +799,11 @@ Example configuration:
 ```json5
 {
   "input": {
-    "maxFileSize": 50000000
+    "maxFileSize": 50000000,
+    "imports": {
+      "enabled": false,
+      "maxDepth": 3
+    }
   },
   "output": {
     "filePath": "repomix-output.xml",

--- a/src/cli/actions/defaultAction.ts
+++ b/src/cli/actions/defaultAction.ts
@@ -195,6 +195,15 @@ export const buildCliConfig = (options: CliOptions): RepomixConfigCli => {
   if (options.tokenCountEncoding) {
     cliConfig.tokenCount = { encoding: options.tokenCountEncoding };
   }
+  if (options.importsMaxDepth !== undefined) {
+    cliConfig.input = {
+      ...cliConfig.input,
+      imports: {
+        ...cliConfig.input?.imports,
+        maxDepth: options.importsMaxDepth,
+      },
+    };
+  }
   if (options.instructionFilePath) {
     cliConfig.output = {
       ...cliConfig.output,

--- a/src/cli/cliRun.ts
+++ b/src/cli/cliRun.ts
@@ -91,6 +91,8 @@ export const run = async () => {
       .option('--no-security-check', 'disable security check')
       // Token Count Options
       .option('--token-count-encoding <encoding>', 'specify token count encoding (e.g., o200k_base, cl100k_base)')
+      // Import Options
+      .option('--imports-max-depth <number>', 'specify the maximum depth for resolving imports', Number.parseInt)
       // MCP
       .option('--mcp', 'run as a MCP server')
       // Other Options

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -49,6 +49,7 @@ export interface CliOptions extends OptionValues {
   mcp?: boolean;
 
   // Other Options
+  importsMaxDepth?: number;
   topFilesLen?: number;
   verbose?: boolean;
   quiet?: boolean;

--- a/tests/cli/actions/defaultAction.test.ts
+++ b/tests/cli/actions/defaultAction.test.ts
@@ -572,4 +572,22 @@ describe('defaultAction', () => {
       );
     });
   });
+
+  describe('importsMaxDepth option', () => {
+    it('should handle --imports-max-depth option', async () => {
+      const options: CliOptions = {
+        importsMaxDepth: 5,
+      };
+
+      await runDefaultAction(['.'], process.cwd(), options);
+
+      expect(configLoader.mergeConfigs).toHaveBeenCalledWith(
+        process.cwd(),
+        expect.anything(),
+        expect.objectContaining({
+          input: { imports: { maxDepth: 5 } },
+        }),
+      );
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- allow setting `--imports-max-depth` via CLI
- handle the new option in CLI config builder
- expose new `importsMaxDepth` option type
- document import depth option in README
- test passing import depth option

## Testing
- `npm run lint` *(fails: Found 4 errors)*
- `npm run test`