### PR TITLE
Refactor import handlers into separate modules

### DIFF
--- a/src/core/file/importHandlers/JavaScriptImportHandler.ts
+++ b/src/core/file/importHandlers/JavaScriptImportHandler.ts
@@ -1,0 +1,47 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import type { LanguageImportHandler } from './LanguageImportHandler.js';
+
+export const jsExtensions = ['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs', '.json'];
+
+const extractJsImports = (content: string): string[] => {
+  const importRegex = /import\s+(?:[^'";]+\s+from\s+)?['"]([^'";]+)['"]/g;
+  const requireRegex = /require\(\s*['"]([^'";]+)['"]\s*\)/g;
+  const imports = [
+    ...Array.from(content.matchAll(importRegex), (m) => m[1]),
+    ...Array.from(content.matchAll(requireRegex), (m) => m[1]),
+  ];
+  return imports.filter((p) => p.startsWith('.'));
+};
+
+const resolveJsImportPath: LanguageImportHandler['resolveImportPath'] = async (spec, fromDir, rootDir) => {
+  const basePath = path.normalize(path.join(fromDir, spec));
+  for (const ext of [''].concat(jsExtensions)) {
+    const filePath = path.join(rootDir, basePath + ext);
+    try {
+      const stats = await fs.stat(filePath);
+      if (stats.isFile()) {
+        return path.relative(rootDir, filePath);
+      }
+    } catch {
+      // ignore
+    }
+  }
+  for (const ext of jsExtensions) {
+    const indexPath = path.join(rootDir, basePath, `index${ext}`);
+    try {
+      const stats = await fs.stat(indexPath);
+      if (stats.isFile()) {
+        return path.relative(rootDir, indexPath);
+      }
+    } catch {
+      // ignore
+    }
+  }
+  return null;
+};
+
+export const JavaScriptImportHandler: LanguageImportHandler = {
+  extractImports: extractJsImports,
+  resolveImportPath: resolveJsImportPath,
+};

--- a/src/core/file/importHandlers/LanguageImportHandler.ts
+++ b/src/core/file/importHandlers/LanguageImportHandler.ts
@@ -1,0 +1,4 @@
+export interface LanguageImportHandler {
+  extractImports(content: string): string[];
+  resolveImportPath(spec: string, fromDir: string, rootDir: string): Promise<string | null>;
+}

--- a/src/core/file/importHandlers/PythonImportHandler.ts
+++ b/src/core/file/importHandlers/PythonImportHandler.ts
@@ -1,0 +1,48 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import type { LanguageImportHandler } from './LanguageImportHandler.js';
+
+const extractPyImports = (content: string): string[] => {
+  const result: string[] = [];
+  const fromRegex = /from\s+([.\w]+)\s+import\s+([\w*, ]+)/g;
+  const importRegex = /import\s+([.\w]+)/g;
+
+  for (const m of content.matchAll(fromRegex)) {
+    const base = m[1];
+    const names = m[2].split(/[,\s]+/).filter(Boolean);
+    for (const name of names) {
+      if (base.startsWith('.')) {
+        result.push(`${base}.${name}`);
+      }
+    }
+  }
+  for (const m of content.matchAll(importRegex)) {
+    const spec = m[1];
+    if (spec.startsWith('.')) {
+      result.push(spec);
+    }
+  }
+  return result;
+};
+
+const resolvePyImportPath: LanguageImportHandler['resolveImportPath'] = async (spec, fromDir, rootDir) => {
+  const rel = spec.replace(/^\.+/, (dots) => '../'.repeat(dots.length - 1)).replace(/\./g, '/');
+  const basePath = path.normalize(path.join(fromDir, rel));
+  const candidates = [path.join(rootDir, `${basePath}.py`), path.join(rootDir, basePath, '__init__.py')];
+  for (const filePath of candidates) {
+    try {
+      const stats = await fs.stat(filePath);
+      if (stats.isFile()) {
+        return path.relative(rootDir, filePath);
+      }
+    } catch {
+      // ignore
+    }
+  }
+  return null;
+};
+
+export const PythonImportHandler: LanguageImportHandler = {
+  extractImports: extractPyImports,
+  resolveImportPath: resolvePyImportPath,
+};

--- a/src/core/file/importHandlers/RustImportHandler.ts
+++ b/src/core/file/importHandlers/RustImportHandler.ts
@@ -1,0 +1,48 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import type { LanguageImportHandler } from './LanguageImportHandler.js';
+
+const extractRustImports = (content: string): string[] => {
+  const modRegex = /mod\s+([A-Za-z0-9_]+)/g;
+  const useRegex = /use\s+(?:crate|self|super)::([A-Za-z0-9_:]+)/g;
+  const imports = [
+    ...Array.from(content.matchAll(modRegex), (m) => m[1]),
+    ...Array.from(content.matchAll(useRegex), (m) => m[1]),
+  ];
+  return imports;
+};
+
+const resolveRustImportPath: LanguageImportHandler['resolveImportPath'] = async (spec, fromDir, rootDir) => {
+  let baseDir = rootDir;
+  let target = spec;
+  if (spec.startsWith('super::')) {
+    target = spec.replace(/^super::/, '');
+    baseDir = path.join(rootDir, fromDir, '..');
+  } else if (spec.startsWith('self::')) {
+    target = spec.replace(/^self::/, '');
+    baseDir = path.join(rootDir, fromDir);
+  } else if (spec.startsWith('crate::')) {
+    target = spec.replace(/^crate::/, '');
+  } else {
+    baseDir = path.join(rootDir, fromDir);
+  }
+
+  const relative = target.replace(/::/g, '/');
+  const candidates = [path.join(baseDir, `${relative}.rs`), path.join(baseDir, relative, 'mod.rs')];
+  for (const filePath of candidates) {
+    try {
+      const stats = await fs.stat(filePath);
+      if (stats.isFile()) {
+        return path.relative(rootDir, filePath);
+      }
+    } catch {
+      // ignore
+    }
+  }
+  return null;
+};
+
+export const RustImportHandler: LanguageImportHandler = {
+  extractImports: extractRustImports,
+  resolveImportPath: resolveRustImportPath,
+};

--- a/src/core/file/importHandlers/index.ts
+++ b/src/core/file/importHandlers/index.ts
@@ -1,0 +1,18 @@
+import { JavaScriptImportHandler, jsExtensions } from './JavaScriptImportHandler.js';
+import type { LanguageImportHandler } from './LanguageImportHandler.js';
+import { PythonImportHandler } from './PythonImportHandler.js';
+import { RustImportHandler } from './RustImportHandler.js';
+
+const handlers: Record<string, LanguageImportHandler> = {};
+
+for (const ext of jsExtensions) {
+  handlers[ext] = JavaScriptImportHandler;
+}
+handlers['.py'] = PythonImportHandler;
+handlers['.rs'] = RustImportHandler;
+
+export const getImportHandler = (ext: string): LanguageImportHandler | null => {
+  return handlers[ext] ?? null;
+};
+
+export type { LanguageImportHandler } from './LanguageImportHandler.js';

--- a/src/core/file/importResolver.ts
+++ b/src/core/file/importResolver.ts
@@ -1,57 +1,10 @@
-import fs from 'node:fs/promises';
 import path from 'node:path';
 import { minimatch } from 'minimatch';
 import type { RepomixConfigMerged } from '../../config/configSchema.js';
 import { logger } from '../../shared/logger.js';
 import { readRawFile } from './fileRead.js';
 import { getIgnorePatterns } from './fileSearch.js';
-
-const possibleExtensions = ['', '.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs', '.json'];
-
-const extractImports = (content: string): string[] => {
-  const result: string[] = [];
-  const importRegex = /import\s+(?:[^'";]+\s+from\s+)?['"]([^'";]+)['"]/g;
-  const requireRegex = /require\(\s*['"]([^'";]+)['"]\s*\)/g;
-  let match: RegExpExecArray | null;
-  while ((match = importRegex.exec(content))) {
-    result.push(match[1]);
-  }
-  while ((match = requireRegex.exec(content))) {
-    result.push(match[1]);
-  }
-  return result.filter((p) => p.startsWith('.'));
-};
-
-const resolveImportPath = async (
-  spec: string,
-  fromDir: string,
-  rootDir: string,
-): Promise<string | null> => {
-  const basePath = path.normalize(path.join(fromDir, spec));
-  for (const ext of possibleExtensions) {
-    const filePath = path.join(rootDir, basePath + ext);
-    try {
-      const stats = await fs.stat(filePath);
-      if (stats.isFile()) {
-        return path.relative(rootDir, filePath);
-      }
-    } catch {
-      // ignore
-    }
-  }
-  for (const ext of possibleExtensions) {
-    const indexPath = path.join(rootDir, basePath, 'index' + ext);
-    try {
-      const stats = await fs.stat(indexPath);
-      if (stats.isFile()) {
-        return path.relative(rootDir, indexPath);
-      }
-    } catch {
-      // ignore
-    }
-  }
-  return null;
-};
+import { getImportHandler } from './importHandlers/index.js';
 
 export const collectImportedFilePaths = async (
   filePaths: string[],
@@ -70,14 +23,18 @@ export const collectImportedFilePaths = async (
   const queue = filePaths.map((p) => ({ path: p, depth: 0 }));
 
   while (queue.length > 0) {
-    const { path: current, depth } = queue.shift()!;
+    const next = queue.shift();
+    if (!next) break;
+    const { path: current, depth } = next;
     if (depth >= maxDepth) continue;
     const fullPath = path.join(rootDir, current);
     const content = await readRawFile(fullPath, config.input.maxFileSize);
     if (!content) continue;
-    const imports = extractImports(content);
+    const handler = getImportHandler(path.extname(current));
+    if (!handler) continue;
+    const imports = handler.extractImports(content);
     for (const spec of imports) {
-      const resolved = await resolveImportPath(spec, path.dirname(current), rootDir);
+      const resolved = await handler.resolveImportPath(spec, path.dirname(current), rootDir);
       if (!resolved) continue;
       if (ignorePatterns.some((pattern) => minimatch(resolved, pattern))) {
         continue;

--- a/tests/cli/actions/defaultAction.test.ts
+++ b/tests/cli/actions/defaultAction.test.ts
@@ -21,6 +21,7 @@ describe('defaultAction', () => {
       cwd: process.cwd(),
       input: {
         maxFileSize: 50 * 1024 * 1024,
+        imports: { enabled: false, maxDepth: 3 },
       },
       output: {
         filePath: 'output.txt',

--- a/tests/cli/cliRun.test.ts
+++ b/tests/cli/cliRun.test.ts
@@ -60,6 +60,7 @@ describe('cliRun', () => {
         cwd: process.cwd(),
         input: {
           maxFileSize: 50 * 1024 * 1024,
+          imports: { enabled: false, maxDepth: 3 },
         },
         output: {
           filePath: 'repomix-output.txt',
@@ -111,6 +112,7 @@ describe('cliRun', () => {
         cwd: process.cwd(),
         input: {
           maxFileSize: 50 * 1024 * 1024,
+          imports: { enabled: false, maxDepth: 3 },
         },
         output: {
           filePath: 'repomix-output.txt',

--- a/tests/core/file/importResolver.python.test.ts
+++ b/tests/core/file/importResolver.python.test.ts
@@ -1,0 +1,33 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import { collectImportedFilePaths } from '../../../src/core/file/importResolver.js';
+import { createMockConfig } from '../../testing/testUtils.js';
+
+let tempDir: string;
+
+beforeEach(async () => {
+  tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'repomix-import-'));
+});
+
+afterEach(async () => {
+  await fs.rm(tempDir, { recursive: true, force: true });
+});
+
+describe('collectImportedFilePaths python', () => {
+  test('resolves python relative imports', async () => {
+    await fs.writeFile(path.join(tempDir, 'index.py'), 'from .pkg import helper\n');
+    await fs.mkdir(path.join(tempDir, 'pkg'));
+    await fs.writeFile(path.join(tempDir, 'pkg', '__init__.py'), '');
+    await fs.writeFile(path.join(tempDir, 'pkg', 'helper.py'), 'def helper(): pass');
+
+    const config = createMockConfig({
+      include: ['index.py'],
+      input: { imports: { enabled: true } },
+    });
+
+    const result = await collectImportedFilePaths(['index.py'], tempDir, config);
+    expect(result).toEqual(['pkg/helper.py']);
+  });
+});

--- a/tests/core/file/importResolver.rust.test.ts
+++ b/tests/core/file/importResolver.rust.test.ts
@@ -1,0 +1,31 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import { collectImportedFilePaths } from '../../../src/core/file/importResolver.js';
+import { createMockConfig } from '../../testing/testUtils.js';
+
+let tempDir: string;
+
+beforeEach(async () => {
+  tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'repomix-import-'));
+});
+
+afterEach(async () => {
+  await fs.rm(tempDir, { recursive: true, force: true });
+});
+
+describe('collectImportedFilePaths rust', () => {
+  test('resolves rust module imports', async () => {
+    await fs.writeFile(path.join(tempDir, 'lib.rs'), 'mod util;');
+    await fs.writeFile(path.join(tempDir, 'util.rs'), '');
+
+    const config = createMockConfig({
+      include: ['lib.rs'],
+      input: { imports: { enabled: true } },
+    });
+
+    const result = await collectImportedFilePaths(['lib.rs'], tempDir, config);
+    expect(result).toEqual(['util.rs']);
+  });
+});

--- a/tests/core/metrics/diffTokenCount.test.ts
+++ b/tests/core/metrics/diffTokenCount.test.ts
@@ -52,7 +52,7 @@ index 123..456 100644
     // Sample config with diffs enabled
     const config: RepomixConfigMerged = {
       cwd: '/test',
-      input: { maxFileSize: 1000000 },
+      input: { maxFileSize: 1000000, imports: { enabled: false, maxDepth: 3 } },
       output: {
         filePath: 'output.txt',
         style: 'plain',
@@ -137,7 +137,7 @@ index 123..456 100644
     // Sample config with diffs disabled
     const config: RepomixConfigMerged = {
       cwd: '/test',
-      input: { maxFileSize: 1000000 },
+      input: { maxFileSize: 1000000, imports: { enabled: false, maxDepth: 3 } },
       output: {
         filePath: 'output.txt',
         style: 'plain',
@@ -213,7 +213,7 @@ index 123..456 100644
     // Sample config with diffs enabled but no content
     const config: RepomixConfigMerged = {
       cwd: '/test',
-      input: { maxFileSize: 1000000 },
+      input: { maxFileSize: 1000000, imports: { enabled: false, maxDepth: 3 } },
       output: {
         filePath: 'output.txt',
         style: 'plain',

--- a/tests/core/treeSitter/parseFile.solidity.test.ts
+++ b/tests/core/treeSitter/parseFile.solidity.test.ts
@@ -9,6 +9,7 @@ describe('Solidity File Parsing', () => {
     cwd: process.cwd(),
     input: {
       maxFileSize: 50 * 1024 * 1024,
+      imports: { enabled: false, maxDepth: 3 },
     },
     output: {
       filePath: 'output.txt',

--- a/tests/mcp/tools/packCodebaseTool.test.ts
+++ b/tests/mcp/tools/packCodebaseTool.test.ts
@@ -58,6 +58,7 @@ describe('PackCodebaseTool', () => {
       config: {
         input: {
           maxFileSize: 50 * 1024 * 1024,
+          imports: { enabled: false, maxDepth: 3 },
         },
         output: {
           filePath: opts.output ?? '/temp/dir/repomix-output.xml',


### PR DESCRIPTION
## Summary
- separate language-specific import handlers into their own files
- expose a helper to choose an import handler by extension
- simplify `collectImportedFilePaths` using the new handler map
- split multi-language tests into dedicated Python and Rust files

## Testing
- `npm run lint`
- `npm run test`
