### PR TITLE
Fix TypeScript import detection

### DIFF
--- a/tests/core/file/importResolver.test.ts
+++ b/tests/core/file/importResolver.test.ts
@@ -18,7 +18,10 @@ afterEach(async () => {
 describe('collectImportedFilePaths', () => {
   test('collects imported files recursively', async () => {
     await fs.writeFile(path.join(tempDir, 'index.js'), "import { greet } from './utils.js';");
-    await fs.writeFile(path.join(tempDir, 'utils.js'), "import { helper } from './helper.js'; export function greet() {};");
+    await fs.writeFile(
+      path.join(tempDir, 'utils.js'),
+      "import { helper } from './helper.js'; export function greet() {};",
+    );
     await fs.writeFile(path.join(tempDir, 'helper.js'), 'export const helper = () => {}');
 
     const config = createMockConfig({
@@ -96,11 +99,21 @@ describe('collectImportedFilePaths', () => {
     expect(result).toEqual(['utils.ts']);
   });
 
+  test("resolves '.js' spec to TypeScript source", async () => {
+    await fs.writeFile(path.join(tempDir, 'index.ts'), "import { x } from './util.js';");
+    await fs.writeFile(path.join(tempDir, 'util.ts'), 'export const x = 1;');
+
+    const config = createMockConfig({
+      include: ['index.ts'],
+      input: { imports: { enabled: true } },
+    });
+
+    const result = await collectImportedFilePaths(['index.ts'], tempDir, config);
+    expect(result).toEqual(['util.ts']);
+  });
+
   test('supports require syntax', async () => {
-    await fs.writeFile(
-      path.join(tempDir, 'index.js'),
-      "const u = require('./util.js');",
-    );
+    await fs.writeFile(path.join(tempDir, 'index.js'), "const u = require('./util.js');");
     await fs.writeFile(path.join(tempDir, 'util.js'), "import './helper.js';");
     await fs.writeFile(path.join(tempDir, 'helper.js'), 'console.log(1);');
 
@@ -123,11 +136,7 @@ describe('collectImportedFilePaths', () => {
       input: { imports: { enabled: true } },
     });
 
-    const result = await collectImportedFilePaths(
-      ['index.js', 'other.js'],
-      tempDir,
-      config,
-    );
+    const result = await collectImportedFilePaths(['index.js', 'other.js'], tempDir, config);
     expect(result).toEqual(['a.js']);
   });
 });


### PR DESCRIPTION
## Summary
- resolve JS imports to their TS source files by testing multiple candidate paths
- add regression test covering `.js` specs that resolve to `.ts`

## Testing
- `npm test`
- `npm run lint`
