### PR TITLE
Improve import handling for Python and TypeScript

### DIFF
--- a/tests/core/file/importResolver.python.test.ts
+++ b/tests/core/file/importResolver.python.test.ts
@@ -30,4 +30,19 @@ describe('collectImportedFilePaths python', () => {
     const result = await collectImportedFilePaths(['index.py'], tempDir, config);
     expect(result).toEqual(['pkg/helper.py']);
   });
+
+  test('resolves python absolute imports for local modules', async () => {
+    await fs.writeFile(path.join(tempDir, 'index.py'), 'from pkg.helper import func\n');
+    await fs.mkdir(path.join(tempDir, 'pkg'));
+    await fs.writeFile(path.join(tempDir, 'pkg', '__init__.py'), '');
+    await fs.writeFile(path.join(tempDir, 'pkg', 'helper.py'), 'def func(): pass');
+
+    const config = createMockConfig({
+      include: ['index.py'],
+      input: { imports: { enabled: true } },
+    });
+
+    const result = await collectImportedFilePaths(['index.py'], tempDir, config);
+    expect(result).toEqual(['pkg/helper.py']);
+  });
 });

--- a/tests/core/file/importResolver.test.ts
+++ b/tests/core/file/importResolver.test.ts
@@ -18,7 +18,10 @@ afterEach(async () => {
 describe('collectImportedFilePaths', () => {
   test('collects imported files recursively', async () => {
     await fs.writeFile(path.join(tempDir, 'index.js'), "import { greet } from './utils.js';");
-    await fs.writeFile(path.join(tempDir, 'utils.js'), "import { helper } from './helper.js'; export function greet() {};");
+    await fs.writeFile(
+      path.join(tempDir, 'utils.js'),
+      "import { helper } from './helper.js'; export function greet() {};",
+    );
     await fs.writeFile(path.join(tempDir, 'helper.js'), 'export const helper = () => {}');
 
     const config = createMockConfig({
@@ -97,10 +100,7 @@ describe('collectImportedFilePaths', () => {
   });
 
   test('supports require syntax', async () => {
-    await fs.writeFile(
-      path.join(tempDir, 'index.js'),
-      "const u = require('./util.js');",
-    );
+    await fs.writeFile(path.join(tempDir, 'index.js'), "const u = require('./util.js');");
     await fs.writeFile(path.join(tempDir, 'util.js'), "import './helper.js';");
     await fs.writeFile(path.join(tempDir, 'helper.js'), 'console.log(1);');
 
@@ -123,11 +123,7 @@ describe('collectImportedFilePaths', () => {
       input: { imports: { enabled: true } },
     });
 
-    const result = await collectImportedFilePaths(
-      ['index.js', 'other.js'],
-      tempDir,
-      config,
-    );
+    const result = await collectImportedFilePaths(['index.js', 'other.js'], tempDir, config);
     expect(result).toEqual(['a.js']);
   });
 });


### PR DESCRIPTION
## Summary
- expand Python import resolution to cover absolute module imports
- test absolute Python imports
- refine JavaScript import resolution to try more candidate paths

## Testing
- `npm test`
- `npm run lint`
