### PR TITLE
Fix Python import resolution

### DIFF
--- a/src/core/file/importHandlers/PythonImportHandler.ts
+++ b/src/core/file/importHandlers/PythonImportHandler.ts
@@ -4,41 +4,72 @@ import type { LanguageImportHandler } from './LanguageImportHandler.js';
 
 const extractPyImports = (content: string): string[] => {
   const result: string[] = [];
-  const fromRegex = /from\s+([.\w]+)\s+import\s+([\w*, ]+)/g;
-  const importRegex = /import\s+([.\w]+)/g;
+  const fromRegex = /from\s+([.\w]+)\s+import\s+([^\n]+)/g;
+  const importRegex = /^\s*import\s+([^\n]+)/gm;
 
   for (const m of content.matchAll(fromRegex)) {
     const base = m[1];
-    const names = m[2].split(/[,\s]+/).filter(Boolean);
-    for (const name of names) {
-      if (base.startsWith('.')) {
+    const names = m[2]
+      .split(',')
+      .map((n) => n.trim().split(/\s+/)[0])
+      .filter(Boolean);
+    if (base.startsWith('.')) {
+      for (const name of names) {
         result.push(`${base}.${name}`);
       }
+    } else {
+      result.push(base);
     }
   }
+
   for (const m of content.matchAll(importRegex)) {
-    const spec = m[1];
-    if (spec.startsWith('.')) {
+    const specs = m[1]
+      .split(',')
+      .map((s) => s.trim().split(/\s+/)[0])
+      .filter(Boolean);
+    for (const spec of specs) {
       result.push(spec);
     }
   }
+
   return result;
 };
 
 const resolvePyImportPath: LanguageImportHandler['resolveImportPath'] = async (spec, fromDir, rootDir) => {
-  const rel = spec.replace(/^\.+/, (dots) => '../'.repeat(dots.length - 1)).replace(/\./g, '/');
-  const basePath = path.normalize(path.join(fromDir, rel));
-  const candidates = [path.join(rootDir, `${basePath}.py`), path.join(rootDir, basePath, '__init__.py')];
-  for (const filePath of candidates) {
-    try {
-      const stats = await fs.stat(filePath);
-      if (stats.isFile()) {
-        return path.relative(rootDir, filePath);
-      }
-    } catch {
-      // ignore
+  const isRelative = spec.startsWith('.');
+  const specPath = spec.replace(/^\.+/, (dots) => '../'.repeat(dots.length - 1)).replace(/\./g, '/');
+
+  const normalizedFromDir = fromDir === '.' ? '' : fromDir;
+
+  const searchDirs: string[] = [];
+  if (isRelative) {
+    searchDirs.push(normalizedFromDir);
+  } else {
+    // For absolute imports, mimic Python's search path by starting from the
+    // importing file's directory and walking up to the repository root.
+    let dir = normalizedFromDir;
+    while (true) {
+      searchDirs.push(dir === '.' ? '' : dir);
+      if (dir === '' || dir === '.') break;
+      dir = path.dirname(dir);
     }
   }
+
+  for (const dir of searchDirs) {
+    const basePath = path.normalize(path.join(dir, specPath));
+    const candidates = [path.join(rootDir, `${basePath}.py`), path.join(rootDir, basePath, '__init__.py')];
+    for (const filePath of candidates) {
+      try {
+        const stats = await fs.stat(filePath);
+        if (stats.isFile()) {
+          return path.relative(rootDir, filePath);
+        }
+      } catch {
+        // ignore
+      }
+    }
+  }
+
   return null;
 };
 

--- a/tests/core/file/importResolver.python.test.ts
+++ b/tests/core/file/importResolver.python.test.ts
@@ -30,4 +30,19 @@ describe('collectImportedFilePaths python', () => {
     const result = await collectImportedFilePaths(['index.py'], tempDir, config);
     expect(result).toEqual(['pkg/helper.py']);
   });
+
+  test('resolves python absolute imports', async () => {
+    await fs.writeFile(path.join(tempDir, 'index.py'), 'from pkg.helper import foo\n');
+    await fs.mkdir(path.join(tempDir, 'pkg'));
+    await fs.writeFile(path.join(tempDir, 'pkg', '__init__.py'), '');
+    await fs.writeFile(path.join(tempDir, 'pkg', 'helper.py'), 'def foo(): pass');
+
+    const config = createMockConfig({
+      include: ['index.py'],
+      input: { imports: { enabled: true } },
+    });
+
+    const result = await collectImportedFilePaths(['index.py'], tempDir, config);
+    expect(result).toEqual(['pkg/helper.py']);
+  });
 });

--- a/tests/core/file/importResolver.test.ts
+++ b/tests/core/file/importResolver.test.ts
@@ -18,7 +18,10 @@ afterEach(async () => {
 describe('collectImportedFilePaths', () => {
   test('collects imported files recursively', async () => {
     await fs.writeFile(path.join(tempDir, 'index.js'), "import { greet } from './utils.js';");
-    await fs.writeFile(path.join(tempDir, 'utils.js'), "import { helper } from './helper.js'; export function greet() {};");
+    await fs.writeFile(
+      path.join(tempDir, 'utils.js'),
+      "import { helper } from './helper.js'; export function greet() {};",
+    );
     await fs.writeFile(path.join(tempDir, 'helper.js'), 'export const helper = () => {}');
 
     const config = createMockConfig({
@@ -97,10 +100,7 @@ describe('collectImportedFilePaths', () => {
   });
 
   test('supports require syntax', async () => {
-    await fs.writeFile(
-      path.join(tempDir, 'index.js'),
-      "const u = require('./util.js');",
-    );
+    await fs.writeFile(path.join(tempDir, 'index.js'), "const u = require('./util.js');");
     await fs.writeFile(path.join(tempDir, 'util.js'), "import './helper.js';");
     await fs.writeFile(path.join(tempDir, 'helper.js'), 'console.log(1);');
 
@@ -123,11 +123,7 @@ describe('collectImportedFilePaths', () => {
       input: { imports: { enabled: true } },
     });
 
-    const result = await collectImportedFilePaths(
-      ['index.js', 'other.js'],
-      tempDir,
-      config,
-    );
+    const result = await collectImportedFilePaths(['index.js', 'other.js'], tempDir, config);
     expect(result).toEqual(['a.js']);
   });
 });


### PR DESCRIPTION
## Summary
- expand Python imports to catch absolute paths and use the first package found
- add absolute import test for Python

## Testing
- `npm run lint`
- `npm test`
